### PR TITLE
Fixing isPrivateOrParameterInPrivateMethod missing issue. Fixes #30

### DIFF
--- a/src/main/kotlin/com/madrapps/dagger/validation/InjectProblem.kt
+++ b/src/main/kotlin/com/madrapps/dagger/validation/InjectProblem.kt
@@ -2,7 +2,6 @@ package com.madrapps.dagger.validation
 
 import com.intellij.psi.PsiElement
 import com.madrapps.dagger.utils.*
-import org.jetbrains.kotlin.asJava.classes.isPrivateOrParameterInPrivateMethod
 import org.jetbrains.uast.*
 
 object InjectProblem : Problem {

--- a/src/main/kotlin/com/madrapps/dagger/validation/Problem.kt
+++ b/src/main/kotlin/com/madrapps/dagger/validation/Problem.kt
@@ -1,9 +1,11 @@
 package com.madrapps.dagger.validation
 
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiModifierListOwner
+import com.intellij.psi.PsiParameter
 import com.intellij.psi.impl.source.PsiClassReferenceType
 import com.madrapps.dagger.utils.*
-import org.jetbrains.kotlin.asJava.classes.isPrivateOrParameterInPrivateMethod
 import org.jetbrains.uast.UMethod
 import org.jetbrains.uast.getContainingUClass
 
@@ -82,4 +84,11 @@ fun UMethod.validateModuleClass(range: PsiElement, error: String): List<Problem.
     return if (!uClass.isModule) {
         range.errors(error)
     } else emptyList()
+}
+
+fun PsiModifierListOwner.isPrivateOrParameterInPrivateMethod(): Boolean {
+    if (hasModifierProperty("private")) return true
+    if (this !is PsiParameter) return false
+    val parentMethod = declarationScope as? PsiMethod ?: return false
+    return parentMethod.hasModifierProperty("private")
 }


### PR DESCRIPTION
Since the `PsiModifierListOwner.isPrivateOrParameterInPrivateMethod()` is removed in the latest version of Kotlin, added a custom implementation for it.