### PR TITLE
Add Kotlin 1.6 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'com.google.dagger:dagger-compiler:2.31.2'
     implementation 'com.google.dagger:dagger-android-processor:2.31.2'
     implementation group: 'com.google.dagger', name: 'dagger-spi', version: '2.31.2'
-
+    runtimeOnly group: 'org.jetbrains.kotlinx', name: 'kotlinx-metadata-jvm', version: '0.4.0'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation fileTree(include: ['*.jar'], dir: 'libs')
     kaptTest fileTree(include: ['*.jar'], dir: 'libs')


### PR DESCRIPTION
I found that your plugin doesn't work when i use Kotlin 1.6 in my project. 
It fails with a log message:
`"STDOUT - Dagger Plugin : java.lang.RuntimeException: java.lang.IllegalStateException: Unsupported metadata version. Check that your Kotlin version is >= 1.0 "`

This is because Dagger 2.31.2 currently used in project internally depends on `kotlinx-metadata-jvm:0.2.0`. I thought that the best course of action might be overriding it with `kotlinx-metadata-jvm:0.4.0` in project's build.gradle file, thus avoiding raising Dagger version.